### PR TITLE
Variable size types to fixed size types

### DIFF
--- a/include/AddonFormat.h
+++ b/include/AddonFormat.h
@@ -1,15 +1,15 @@
 
 #ifndef ADDON_FORMAT_H
 #define ADDON_FORMAT_H
+#include <stdint.h>
 #include "Bootil/Bootil.h"
-
 
 namespace Addon
 {
 	static const char*	Ident							= "GMAD";
 	static const char	Version							= 3;
-	static const unsigned int AppID						= 4000;
-	static const unsigned int CompressionSignature		= 0xBEEFCACE;
+	static const uint32_t AppID						= 4000;
+	static const uint32_t CompressionSignature		= 0xBEEFCACE;
 
 
 	struct Header
@@ -21,10 +21,10 @@ namespace Addon
 	struct FileEntry
 	{
 		Bootil::BString	strName;
-		long long		iSize;
-		unsigned long	iCRC;
-		unsigned int	iFileNumber;
-		long long		iOffset;
+		int64_t		iSize;
+		uint32_t	iCRC;
+		uint32_t	iFileNumber;
+		int64_t		iOffset;
 
 		typedef std::list< FileEntry > List;
 	};
@@ -95,9 +95,9 @@ namespace Addon
 	};
 
 	//
-	// This is the position in the file containing a 64 bit unsigned int that represents the file's age
+	// This is the position in the file containing a 64 bit uint32_t that represents the file's age
 	// It's basically the time it was uploaded to Steam - and is set on download/extraction from steam.
 	//
-	static unsigned int			TimestampOffset			= sizeof( Addon::Header ) + sizeof( unsigned long long );
+	static uint32_t			TimestampOffset			= sizeof( Addon::Header ) + sizeof( uint64_t );
 }
 #endif

--- a/include/AddonReader.h
+++ b/include/AddonReader.h
@@ -2,8 +2,10 @@
 #ifndef ADDONREADER_H
 #define ADDONREADER_H
 
+#include <stdint.h>
 #include "Bootil/Bootil.h"
 #include "AddonFormat.h"
+
 
 //
 //
@@ -53,8 +55,8 @@ namespace Addon
 				if ( m_fmtversion > Addon::Version )
 					return false;
 
-				m_buffer.ReadType<unsigned long long>(); // steamid
-				m_buffer.ReadType<unsigned long long>(); // timestamp
+				m_buffer.ReadType<uint64_t>(); // steamid
+				m_buffer.ReadType<uint64_t>(); // timestamp
 
 				//
 				// Required content (not used at the moment, just read out)
@@ -75,19 +77,19 @@ namespace Addon
 				//
 				// Addon version - unused
 				//
-				m_buffer.ReadType<int>();
+				m_buffer.ReadType<int32_t>();
 				//
 				// File index
 				//
-				int iFileNumber = 1;
-				int iOffset = 0;
+				int32_t iFileNumber = 1;
+				int32_t iOffset = 0;
 
-				while ( m_buffer.ReadType<unsigned int>() != 0 )
+				while ( m_buffer.ReadType<uint32_t>() != 0 )
 				{
 					Addon::FileEntry entry;
 					entry.strName		= m_buffer.ReadString();
-					entry.iSize			= m_buffer.ReadType<long long>();
-					entry.iCRC			= m_buffer.ReadType<unsigned long>();
+					entry.iSize			= m_buffer.ReadType<int64_t>();
+					entry.iCRC			= m_buffer.ReadType<uint32_t>();
 					entry.iOffset		= iOffset;
 					entry.iFileNumber	= iFileNumber;
 					m_index.push_back( entry );
@@ -118,7 +120,7 @@ namespace Addon
 			//
 			// Return the FileEntry for a FileID
 			//
-			bool GetFile( unsigned int iFileID, Addon::FileEntry& outfile )
+			bool GetFile( uint32_t iFileID, Addon::FileEntry& outfile )
 			{
 				BOOTIL_FOREACH( file, m_index, Addon::FileEntry::List )
 				{
@@ -134,7 +136,7 @@ namespace Addon
 			//
 			// Read a fileid from the addon into the buffer
 			//
-			bool ReadFile( unsigned int iFileID, Bootil::Buffer& buffer )
+			bool ReadFile( uint32_t iFileID, Bootil::Buffer& buffer )
 			{
 				Addon::FileEntry file;
 
@@ -161,7 +163,7 @@ namespace Addon
 			}
 
 			const Addon::FileEntry::List& GetList() { return m_index; }
-			unsigned int GetFormatVersion() { return m_fmtversion; }
+			uint32_t GetFormatVersion() { return m_fmtversion; }
 			const Bootil::Buffer& GetBuffer() { return m_buffer; }
 			Bootil::BString Title() { return m_name; }
 			Bootil::BString Description() { return m_desc; }
@@ -178,7 +180,7 @@ namespace Addon
 			Bootil::BString			m_desc;
 			Bootil::BString			m_type;
 			Addon::FileEntry::List	m_index;
-			unsigned long			m_fileblock;
+			uint32_t			m_fileblock;
 
 			Bootil::String::List	m_tags;
 

--- a/src/create_gmad.cpp
+++ b/src/create_gmad.cpp
@@ -63,9 +63,9 @@ namespace CreateAddon
 		buffer.Write( Addon::Ident, 4 );				// Ident (4)
 		buffer.WriteType( ( char ) Addon::Version );		// Version (1)
 		// SteamID (8) [unused]
-		buffer.WriteType( ( unsigned long long ) 0ULL );
+		buffer.WriteType( ( uint64_t ) 0ULL );
 		// TimeStamp (8)
-		buffer.WriteType( ( unsigned long long ) Bootil::Time::UnixTimestamp() );
+		buffer.WriteType( ( uint64_t ) Bootil::Time::UnixTimestamp() );
 		// Required content (a list of strings)
 		buffer.WriteType( ( char ) 0 ); // signifies nothing
 		// Addon Name (n)
@@ -75,23 +75,23 @@ namespace CreateAddon
 		// Addon Author (n) [unused]
 		buffer.WriteString( "Author Name" );
 		// Addon Version (4) [unused]
-		buffer.WriteType( ( int ) 1 );
+		buffer.WriteType( ( int32_t ) 1 );
 		// File list
-		unsigned int iFileNum = 0;
+		uint32_t iFileNum = 0;
 		BOOTIL_FOREACH( f, files, String::List )
 		{
-			unsigned long	iCRC = Bootil::File::CRC( strFolder + *f );
-			long long		iSize = Bootil::File::Size( strFolder + *f );
+			uint32_t	iCRC = Bootil::File::CRC( strFolder + *f );
+			int64_t		iSize = Bootil::File::Size( strFolder + *f );
 			iFileNum++;
-			buffer.WriteType( ( unsigned int ) iFileNum );					// File number (4)
+			buffer.WriteType( ( uint32_t ) iFileNum );					// File number (4)
 			buffer.WriteString( String::GetLower( *f ) );					// File name (all lower case!) (n)
-			buffer.WriteType( ( long long ) iSize );							// File size (8)
-			buffer.WriteType( ( unsigned long ) iCRC );						// File CRC (4)
+			buffer.WriteType( ( int64_t ) iSize );							// File size (8)
+			buffer.WriteType( ( uint32_t ) iCRC );						// File CRC (4)
 			Output::Msg( "File index: %s [CRC:%u] [Size:%s]\n", f->c_str(), iCRC, String::Format::Memory( iSize ).c_str() );
 		}
 		// Zero to signify end of files
 		iFileNum = 0;
-		buffer.WriteType( ( unsigned int ) iFileNum );
+		buffer.WriteType( ( uint32_t ) iFileNum );
 		// The files
 		BOOTIL_FOREACH( f, files, String::List )
 		{
@@ -108,7 +108,7 @@ namespace CreateAddon
 			buffer.WriteBuffer( filebuffer );
 		}
 		// CRC what we've written (to verify that the download isn't shitted) (4)
-		unsigned long AddonCRC = Bootil::Hasher::CRC32::Easy( buffer.GetBase(), buffer.GetWritten() );
+		uint32_t AddonCRC = Bootil::Hasher::CRC32::Easy( buffer.GetBase(), buffer.GetWritten() );
 		buffer.WriteType( AddonCRC );
 		return true;
 	}


### PR DESCRIPTION
Modified variables type with architecture dependent size (long, int, long long, etc...) to fixed bit size types from stdint.h (i.e. uint32_t, int32_t, uint64_t, int32_t). Extraction tested successfully in Linux on 32 bit and 64 bit.
