### PR TITLE
Fix iCRC type to make it 4-byte on both 32-bit and 64-bit platforms

### DIFF
--- a/include/AddonFormat.h
+++ b/include/AddonFormat.h
@@ -22,7 +22,7 @@ namespace Addon
 	{
 		Bootil::BString	strName;
 		long long		iSize;
-		unsigned long	iCRC;
+		unsigned int	iCRC;
 		unsigned int	iFileNumber;
 		long long		iOffset;
 

--- a/include/AddonReader.h
+++ b/include/AddonReader.h
@@ -87,7 +87,7 @@ namespace Addon
 					Addon::FileEntry entry;
 					entry.strName		= m_buffer.ReadString();
 					entry.iSize			= m_buffer.ReadType<long long>();
-					entry.iCRC			= m_buffer.ReadType<unsigned long>();
+					entry.iCRC			= m_buffer.ReadType<unsigned int>();
 					entry.iOffset		= iOffset;
 					entry.iFileNumber	= iFileNumber;
 					m_index.push_back( entry );

--- a/src/create_gmad.cpp
+++ b/src/create_gmad.cpp
@@ -80,13 +80,13 @@ namespace CreateAddon
 		unsigned int iFileNum = 0;
 		BOOTIL_FOREACH( f, files, String::List )
 		{
-			unsigned long	iCRC = File::CRC( strFolder + *f );
+			unsigned int	iCRC = File::CRC( strFolder + *f );
 			long long		iSize = File::Size( strFolder + *f );
 			iFileNum++;
 			buffer.WriteType( ( unsigned int ) iFileNum );					// File number (4)
 			buffer.WriteString( String::GetLower( *f ) );					// File name (all lower case!) (n)
 			buffer.WriteType( ( long long ) iSize );						// File size (8)
-			buffer.WriteType( ( unsigned long ) iCRC );						// File CRC (4)
+			buffer.WriteType( ( unsigned int ) iCRC );						// File CRC (4)
 
 			//Output::Msg( "File index: %s [CRC:%u] [Size:%s]\n", f->c_str(), iCRC, String::Format::Memory( iSize ).c_str() );
 		}
@@ -109,7 +109,7 @@ namespace CreateAddon
 			buffer.WriteBuffer( filebuffer );
 		}
 		// CRC what we've written (to verify that the download isn't shitted) (4)
-		unsigned long AddonCRC = Hasher::CRC32::Easy( buffer.GetBase(), buffer.GetWritten() );
+		unsigned int AddonCRC = Hasher::CRC32::Easy( buffer.GetBase(), buffer.GetWritten() );
 		buffer.WriteType( AddonCRC );
 		return true;
 	}


### PR DESCRIPTION
Tried in both OSX (Mountain Lion 64-bit) and Linux (Debian Jessie i386) to extract .gma files, and found some inconsistency between the two. It runs fine in 32-bit Linux, but has some problem in 64-bit OSX. After some digging, it turns out that "unsigned long" have different size in 32-bit and 64-bit platforms.

sizeof(unsigned int) is 4 on both 32-bit and 64-bit platforms.
sizeof(unsigned long) is 4 on 32-bit platform and 8 on 64-bit one.

http://stackoverflow.com/questions/13335587/sizeof-unsigned-int-in-microsoft-x64-compiler