### PR TITLE
Ignore OS X metadata files (.DS_Store)

### DIFF
--- a/include/Addon_Json.h
+++ b/include/Addon_Json.h
@@ -123,6 +123,12 @@ class CAddonJson
 				if ( *f == "addon.json" ) continue;
 
 				//
+				// Don't include OS X metadata files
+				//
+				if ( *f == ".DS_Store" ) continue;
+				if ( Bootil::String::Test::Wildcard( "*/.DS_Store", *f ) ) continue;
+
+				//
 				// Check against our loaded ignores list
 				//
 				BOOTIL_FOREACH( ignore, m_Ignores, Bootil::String::List )


### PR DESCRIPTION
These exist in almost every folder, are hidden and many users will be unaware the file even exists.