### PR TITLE
[Fix] Auto-ignore desktop.ini on Windows

### DIFF
--- a/include/Addon_Json.h
+++ b/include/Addon_Json.h
@@ -123,6 +123,11 @@ class CAddonJson
 				if ( *f == "addon.json" ) continue;
 
 				//
+				// Don't include Windows config file
+				//
+				if ( *f == "desktop.ini" ) continue;
+
+				//
 				// Don't include OS X metadata files
 				//
 				if ( *f == ".DS_Store" ) continue;

--- a/include/Addon_Json.h
+++ b/include/Addon_Json.h
@@ -123,9 +123,11 @@ class CAddonJson
 				if ( *f == "addon.json" ) continue;
 
 				//
-				// Don't include Windows config file
+				// Don't include Windows specifiic files
 				//
-				if ( *f == "desktop.ini" ) continue;
+				Bootil::BString strLow = Bootil::String::GetLower( *f );
+				if ( Bootil::String::Test::Wildcard( "*thumbs.db", strLow ) ) continue;
+				if ( Bootil::String::Test::Wildcard( "*desktop.ini", strLow ) ) continue;
 
 				//
 				// Don't include OS X metadata files


### PR DESCRIPTION
Hello. This pull request fixes the issue with desktop.ini and its interruption. gmad.exe will error if this file exists in folder. This can be fixed by adding it in addon.json -> ignore table. But also can be implemented for automatic ignoring.
@robotboy655 

Requesting to merge. Thanks. Spar#6665